### PR TITLE
Fixes cyborg initial chat and recruitment

### DIFF
--- a/data/json/npcs/TALK_CYBORG_1.json
+++ b/data/json/npcs/TALK_CYBORG_1.json
@@ -4,8 +4,8 @@
     "type": "talk_topic",
     "dynamic_line": "You... You saved me!  *Zzzt* Let me come with you, I can help!",
     "responses": [
-      { "text": "You're on your own.  Bye.", "topic": "TALK_DONE" },
-      { "text": "Of course!  Come with me.", "topic": "TALK_AGREE_FOLLOW" }
+      { "text": "Of course!  Come with me.", "topic": "TALK_AGREE_FOLLOW", "effect": "follow", "opinion": { "trust": 1, "value": 1 } },
+      { "text": "You're on your own.  Bye.", "topic": "TALK_DONE" }
     ]
   }
 ]


### PR DESCRIPTION
Fixes #29774 and makes freed cyborgs actually recruitable. Also throws in a nice little opinion bonus.

#### Summary
Summary: Content "Fixed cyborg initial recruitment dialogue"

#### Purpose of change
Fixes #29774 and allows cyborgs to be recruited.

#### Additional context
Right now, this recruitment dialogue is a little unsubtle. It may be worth looking into putting together a randomized initial opinion modifier that controls whether or not the cyborg will offer to join the player. I'll look into doing this if there is interest.